### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/integrationstraining/1436f396-edbf-4230-822e-19407934105d/fa10db86-c44e-46f4-9b45-c5f95a0f4516/_apis/work/boardbadge/856f63fa-4dbe-4f86-ad7a-e18fac755b9d)](https://dev.azure.com/integrationstraining/1436f396-edbf-4230-822e-19407934105d/_boards/board/t/fa10db86-c44e-46f4-9b45-c5f95a0f4516/Microsoft.RequirementCategory)
 # FoodApp Sample App
 
 A .NET Core Api and Angular UI implemented as Cloud Native App with step by step [Installation Scripts](/az-cli/)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#423](https://dev.azure.com/integrationstraining/1436f396-edbf-4230-822e-19407934105d/_workitems/edit/423). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.